### PR TITLE
feat(cache): cache now obeys Age and a variety of other things

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "checksum-stream": "^1.0.2",
     "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "^1.0.0",
+    "http-cache-semantics": "^3.7.3",
     "lru-cache": "^4.0.2",
     "mississippi": "^1.2.0",
     "node-fetch": "2.0.0-alpha.3",


### PR DESCRIPTION
Fixes: #5

This patch uses [`http-cache-semantics`](https://npm.im/http-cache-semantics)
to provide more "complete" caching support. This means things like the Age
header are now obeyed, heuristics are calculated properly, CC:immutable is
revalidated, etc.

The patch is also a big mess, and m-f-h is due for a nice refactor. heh. :/

/cc @pornel
