### PR TITLE
fix(proxy): fix http-proxy to https conn and socks-proxy

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -149,7 +149,7 @@ function getProxy (proxyUrl, opts, isHttps) {
       return new HttpsProxyAgent(popts)
     }
   }
-  if (proxyUrl.startsWith('socks')) {
+  if (proxyUrl.protocol.startsWith('socks')) {
     if (!SocksProxyAgent) {
       SocksProxyAgent = require('socks-proxy-agent')
     }

--- a/agent.js
+++ b/agent.js
@@ -34,7 +34,7 @@ function getAgent (uri, opts) {
   }
 
   if (pxuri) {
-    const proxy = getProxy(pxuri, opts)
+    const proxy = getProxy(pxuri, opts, isHttps)
     AGENT_CACHE.set(key, proxy)
     return proxy
   }
@@ -120,7 +120,7 @@ function getProxyUri (uri, opts) {
 let HttpProxyAgent
 let HttpsProxyAgent
 let SocksProxyAgent
-function getProxy (proxyUrl, opts) {
+function getProxy (proxyUrl, opts, isHttps) {
   let popts = {
     host: proxyUrl.hostname,
     port: proxyUrl.port,
@@ -134,19 +134,20 @@ function getProxy (proxyUrl, opts) {
     rejectUnauthorized: opts.strictSSL
   }
 
-  if (proxyUrl.protocol === 'http:') {
-    if (!HttpProxyAgent) {
-      HttpProxyAgent = require('http-proxy-agent')
-    }
+  if (proxyUrl.protocol === 'http:' || proxyUrl.protocol === 'https:') {
+    if (!isHttps) {
+      if (!HttpProxyAgent) {
+        HttpProxyAgent = require('http-proxy-agent')
+      }
 
-    return new HttpProxyAgent(popts)
-  }
-  if (proxyUrl.protocol === 'https:') {
-    if (!HttpsProxyAgent) {
-      HttpsProxyAgent = require('https-proxy-agent')
-    }
+      return new HttpProxyAgent(popts)
+    } else {
+      if (!HttpsProxyAgent) {
+        HttpsProxyAgent = require('https-proxy-agent')
+      }
 
-    return new HttpsProxyAgent(popts)
+      return new HttpsProxyAgent(popts)
+    }
   }
   if (proxyUrl.startsWith('socks')) {
     if (!SocksProxyAgent) {


### PR DESCRIPTION

# Known Issue: 

[ ] `npm ERR! cb() never called!` when use `socks-proxy` and connect to http.
[ ] `node` is waiting all proxy conns to disconnected before exit.