### PR TITLE
fix(deps): bump https-proxy-agent with bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "make-fetch-happen",
-  "version": "2.4.10",
+  "version": "2.4.12",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cacache": "^9.2.7",
     "http-cache-semantics": "^3.7.3",
     "http-proxy-agent": "^1.0.0",
-    "https-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^2.0.0",
     "lru-cache": "^4.0.2",
     "mississippi": "^1.2.0",
     "node-fetch-npm": "^2.0.1",


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/npm/npm/issues/16868

**What does it do?**
Updates to `node-https-proxy-agent@2.0.0`
> I've also including a regenerated `package-lock.json` as the *node-https-proxy-agent* update removed a package required by `nyc`, plus a few other changes since `2.4.10`

**What does it fix?**
This fixes missing npm options from https://github.com/npm/npm/issues/16868 (e.g. `cafile` and `strict-ssl`) not working when under a proxy. Particularly when self-signed certificates are used.