### PR TITLE
fix(agent): support timeout durations greater than 30 seconds

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -44,16 +44,25 @@ function getAgent (uri, opts) {
   } else if (!isHttps && !HttpAgent) {
     HttpAgent = require('agentkeepalive')
   }
+
+  // If opts.timeout is zero, set the agentTimeout to zero as well.
+  // A timeout of zero disables the timeout behavior (OS limits still apply).
+  // Else, if opts.timeout is a non-zero value, set it to timeout + 1, to ensure that the node-fetch-npm
+  // timeout will always fire first, giving us more consistent errors.
+  const agentTimeout = (typeof opts.timeout === 'number' && opts.timeout === 0) ? 0 : opts.timeout + 1
+
   const agent = isHttps ? new HttpsAgent({
     maxSockets: opts.maxSockets || 15,
     ca: opts.ca,
     cert: opts.cert,
     key: opts.key,
     localAddress: opts.localAddress,
-    rejectUnauthorized: opts.strictSSL
+    rejectUnauthorized: opts.strictSSL,
+    timeout: agentTimeout
   }) : new HttpAgent({
     maxSockets: opts.maxSockets || 15,
-    localAddress: opts.localAddress
+    localAddress: opts.localAddress,
+    timeout: agentTimeout
   })
   AGENT_CACHE.set(key, agent)
   return agent

--- a/agent.js
+++ b/agent.js
@@ -49,7 +49,7 @@ function getAgent (uri, opts) {
   // A timeout of zero disables the timeout behavior (OS limits still apply).
   // Else, if opts.timeout is a non-zero value, set it to timeout + 1, to ensure that the node-fetch-npm
   // timeout will always fire first, giving us more consistent errors.
-  const agentTimeout = (typeof opts.timeout === 'number' && opts.timeout === 0) ? 0 : opts.timeout + 1
+  const agentTimeout = opts.timeout === 0 ? 0 : opts.timeout + 1
 
   const agent = isHttps ? new HttpsAgent({
     maxSockets: opts.maxSockets || 15,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "standard-version -s",
     "postrelease": "npm publish && git push --follow-tags",
     "pretest": "standard lib test *.js",
-    "test": "nyc --all -- tap -J test/*.js",
+    "test": "nyc --all -- tap --timeout=35 -J test/*.js",
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -310,6 +310,17 @@ test('supports opts.timeout for controlling request timeout time', t => {
   })
 })
 
+test('supports opts.timeout greater than 30 seconds', {timeout: 36000}, t => {
+  const srv = tnock(t, HOST)
+  srv.get('/test').delay(31000).reply(200, CONTENT)
+  return fetch(`${HOST}/test`, {
+    timeout: 35000,
+    retry: { retries: 0 }
+  }).then(res => res.buffer()).then(buf => {
+    t.deepEqual(buf, CONTENT, 'retrieved correct content')
+  })
+})
+
 test('retries non-POST requests on timeouts', t => {
   const srv = tnock(t, HOST)
   let attempt = 0


### PR DESCRIPTION
The current implementation of the test for this fix takes, as you might expect, more than 30 seconds to run. This isn't great. It would be possible to have a faster test that just makes sure that `agentkeepalive` is receiving the correct options, but that wouldn't really ensure that long requests actually work in the real world. Let me know if you would prefer that I take that route instead.

Closes #35.