### PR TITLE
Catch possible TypeError in cached response Vary header validation; resolves #38

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -226,7 +226,14 @@ function matchDetails (req, cached) {
       return false
     } else {
       const fieldsMatch = vary.split(/\s*,\s*/).every(field => {
-        return cached.reqHeaders.get(field) === req.headers.get(field)
+        try {
+          return cached.reqHeaders.get(field) === req.headers.get(field)
+        } catch (e) {
+          if (e instanceof TypeError) {
+            return true
+          }
+          throw e
+        }
       })
       if (!fieldsMatch) {
         return false

--- a/test/cache.js
+++ b/test/cache.js
@@ -802,7 +802,7 @@ test('does not store response if it has Cache-Control: no-store header', t => {
 test('supports matching using Vary header', t => {
   const srv = tnock(t, HOST)
   srv.get('/test').reply(200, CONTENT, {
-    'Vary': 'Accept',
+    'Vary': 'Accept,User-Agent)',
     'Cache-Control': 'immutable',
     'Content-Type': 'fullfat'
   })
@@ -824,6 +824,7 @@ test('supports matching using Vary header', t => {
     t.equal(
       res.headers.get('content-type'), 'fullfat', 'got original content-type'
     )
+    t.equal(res.headers.get('Vary'), 'Accept,User-Agent)', 'invalid header name is skipped')
     return res.buffer()
   }).then(body => {
     t.deepEqual(body, CONTENT, 'got cached content')


### PR DESCRIPTION
This resolves #38 by silently skipping over any invalid header names when inspecting the `Vary` header before using a cached response payload.

I'm not confident that this is the cleanest possible solution to solve this bug, but it does work as expected.

Another alternative is something along the lines of

```javascript
const fieldsMatch = vary.split(...)
  .filter(checkIsHttpToken)
  .every(field => <existing logic>)
```

Though `checkIsHttpToken` does not appear to be exported from either Node or `node-fetch-npm`.