### PR TITLE
fix(license): switch to ISC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,16 @@
-To the extent possible under law, maintainers for this project have waived all copyright and related or neighboring rights to this project.
+ISC License
 
-For more information on this waiver, see: https://creativecommons.org/publicdomain/zero/1.0/
+Copyright (c) npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE COPYRIGHT HOLDER DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "email": "kzm@sykosomatic.org",
     "twitter": "maybekatz"
   },
-  "license": "CC0-1.0",
+  "license": "ISC",
   "dependencies": {
     "agentkeepalive": "^3.3.0",
     "cacache": "^10.0.0",


### PR DESCRIPTION
As part of the ongoing relicensing process, this changes
the license over to one more palatable to open source
consumers.

BREAKING CHANGE: license changed from CC0 to ISC.

### NOTE
This **requires consent** from all contributors. If you're on the list below, **please reply** with "I agree" or a 👍 or something similar to let me know you're ok with your changes being included in this relicensing.

The reason this is happening is because it's pretty hard for some folks to use CC0 stuff, since it's not an OSI-approved license. ISC is the license used by the npm CLI, so I'm switching to it for convenience. We ran all this through our company lawyer before going about it, too, and it's part of a number of relicensing PRs that are happening to related projects I've worked on! Let me know if you have any questions!

* [x] @Lange 
* [x] @yyjdelete 
* [x] @cilice 
* [x] @tmyt 
* [x] @nlkluth 
* [x] @bitinn 
* [x] @SimenB 
* [x] @miiihi 
* [x] @colinrotherham 