### PR TITLE
include pkg name in integrity error msg

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ function conditionalFetch (req, cachedRes, opts) {
     })
 }
 
-function remoteFetchHandleIntegrity (res, integrity) {
+function remoteFetchHandleIntegrity (res, integrity, uri) {
   const oldBod = res.body
   const newBod = ssri.integrityStream({
     integrity
@@ -302,6 +302,7 @@ function remoteFetchHandleIntegrity (res, integrity) {
     newBod.emit('error', err)
   })
   newBod.once('error', err => {
+    err.message += ` for ${uri}`
     oldBod.emit('error', err)
   })
 }
@@ -334,7 +335,7 @@ function remoteFetch (uri, opts) {
           res.headers.set('x-fetch-attempts', attemptNum)
 
           if (opts.integrity) {
-            remoteFetchHandleIntegrity(res, opts.integrity)
+            remoteFetchHandleIntegrity(res, opts.integrity, uri)
           }
 
           const isStream = req.body instanceof Stream


### PR DESCRIPTION
There are a handful of [open integrity issues](https://github.com/npm/npm/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+EINTEGRITY) on npm, one of which is a [feature request to expose the name of the package](https://github.com/npm/npm/issues/17459) which failed the integrity check. This PR adds the name of the failed package to the error message when available. Including the name of the package in the error message allows us to know which module to republish if the package-lock integrity field is ok.

NPM: 5.5.1 & 5.6.0
NodeJS: 4 & 8

Old log snippet:
```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: sha512-ylcamPJlcckW+rK0NwuIN2bJP8a2uMsJv0LcYgd1/reaKd8xpLad2UNTAW8S4MQFfPzBCEVZH1KSjABfOR5IeA== integrity checksum failed when using sha512: wanted sha512-ylcamPJlcckW+rK0NwuIN2bJP8a2uMsJv0LcYgd1/reaKd8xpLad2UNTAW8S4MQFfPzBCEVZH1KSjABfOR5IeA== but got sha512-dTc1sOyafhR0/yiqgDJoXEf9J3r6TBGHg99Y4NIHMKuFwLPSIAPpLrDGoJOor8pPWc+pp2WUDNVQsUgtPXCjcQ==. (3936 bytes)
```

New log snippet:
```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: sha512-ylcamPJlcckW+rK0NwuIN2bJP8a2uMsJv0LcYgd1/reaKd8xpLad2UNTAW8S4MQFfPzBCEVZH1KSjABfOR5IeA== integrity checksum failed when using sha512: wanted sha512-ylcamPJlcckW+rK0NwuIN2bJP8a2uMsJv0LcYgd1/reaKd8xpLad2UNTAW8S4MQFfPzBCEVZH1KSjABfOR5IeA== but got sha512-dTc1sOyafhR0/yiqgDJoXEf9J3r6TBGHg99Y4NIHMKuFwLPSIAPpLrDGoJOor8pPWc+pp2WUDNVQsUgtPXCjcQ==. (3936 bytes) for https://registry.npmjs.org/repository/npm-all/the-pkg-name/-/the-pkg-name-1.3.1.tgz
```

See https://github.com/npm/npm/issues/17459