### PR TITLE
Support for trailing dots when checking no_proxy

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -70,7 +70,7 @@ function getAgent (uri, opts) {
 }
 
 function checkNoProxy (uri, opts) {
-  const host = url.parse(uri).hostname.split('.').reverse()
+  const host = url.parse(uri).hostname.split('.').filter(x => x).reverse()
   let noproxy = (opts.noProxy || getProcessEnv('no_proxy'))
   if (typeof noproxy === 'string') {
     noproxy = noproxy.split(/\s*,\s*/g)


### PR DESCRIPTION
it is perfectly legal for URI to contain trailing dot, but with it no_proxy matching logic breaks. This change fixes it