### PR TITLE
Update Redis cache example to prevent body used twice error

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ class MyCustomRedisCache {
     })
   }
   put (req, res) {
-    return res.buffer().then(body => {
+    const response = res.clone() // clone the response, so the body doesn't get used twice
+    return response.buffer().then(body => {
       return this.redis.setAsync(req.url, JSON.stringify({
         body: body,
-        headers: res.headers.raw()
+        headers: response.headers.raw()
       }))
     }).then(() => {
-      // return the response itself
+      // return the original response itself
       return res
     })
   }


### PR DESCRIPTION
Calling `res.buffer()` marks the body as having already been used, which makes subsequent parsing calls (e.g. `res.json()`) throw [this error](https://github.com/npm/node-fetch-npm/blob/be4a050625d586cadf312d671921cf476ce2b1fa/src/body.js#L144). By using a clone of the response for buffering / saving, the response's parse-ability is preserved to be consistent with a cache-miss response.