### PR TITLE
Update https-proxy-agent to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cacache": "^11.0.1",
     "http-cache-semantics": "^3.8.1",
     "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "lru-cache": "^4.1.2",
     "mississippi": "^3.0.0",
     "node-fetch-npm": "^2.0.2",


### PR DESCRIPTION
https://npmjs.com/advisories/1184
There is a machine in the middle attack possible with version 2.2.1 of https-proxy-agent. Please upgrade to the current version.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
