### PR TITLE
Handle highWaterMark potentially false

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -174,7 +174,7 @@ module.exports = class Cache {
     })
     const oldBody = response.body
     // in readable-stream 3.x, false is not a valid value for highWaterMark
-    const highWaterMark = fitInMemory ? MAX_MEM_SIZE : undefined;
+    const highWaterMark = fitInMemory ? MAX_MEM_SIZE : undefined
     const newBody = through({highWaterMark})
     response.body = newBody
     oldBody.once('error', err => newBody.emit('error', err))

--- a/cache.js
+++ b/cache.js
@@ -173,7 +173,9 @@ module.exports = class Cache {
       cacheTargetStream ? cacheTargetStream.end(done) : done()
     })
     const oldBody = response.body
-    const newBody = through({highWaterMark: fitInMemory && MAX_MEM_SIZE})
+    // in readable-stream 3.x, false is not a valid value for highWaterMark
+    const highWaterMark = fitInMemory ? MAX_MEM_SIZE : undefined;
+    const newBody = through({highWaterMark})
     response.body = newBody
     oldBody.once('error', err => newBody.emit('error', err))
     newBody.once('error', err => oldBody.emit('error', err))


### PR DESCRIPTION
Fixes: #70 (I think)

If the content-length header is empty, `size` gets set to `false`, which is sent in as the `highWaterMark` option to `through2`, which is passed to `readable-stream`, which eventually raises an error saying "false is not a valid value" or something similar, but only on version 3.x, which is what `npm` uses (even though this project doesn't).

I did write a test for this, but could never get it to trigger because it's caused by some sort of dependency mismatch that happens in npm but not in this repo, so I removed the test. Even when I installed readable-stream@3.x, it didn't trigger, because `through2` is the only dependency that requires `readable-stream`, which is not the case in `npm`. When I updated just `through2`'s `readable-stream` version, I got a different error entirely, so I'm not sure if this weird dependency thing is the only issue, but I do know we're not supposed to pass `highWaterMark: false`, so this should still be a valid fix.