### PR TITLE
chore(deps): bump https-proxy-agent from 2.2.1 to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ sudo: false
 node_js:
   - "9"
   - "8"
-  - "6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2119,12 +2119,22 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
       }
     },
     "humanize-ms": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cacache": "^11.0.1",
     "http-cache-semantics": "^3.8.1",
     "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "lru-cache": "^4.1.2",
     "mississippi": "^3.0.0",
     "node-fetch-npm": "^2.0.2",


### PR DESCRIPTION
Updating https-proxy-agent to fix vulnerability. 

Fixes: https://github.com/zkat/make-fetch-happen/issues/75
Related: https://github.com/zkat/make-fetch-happen/pull/71
